### PR TITLE
Update setup.py for adding wheel requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ requirements = [
     'seaborn==0.9.0',
     'spacy==2.1.8',
     'swifter==0.295',
-    'tqdm==4.35.0'
+    'tqdm==4.35.0',
+    'wheel'
     ]
 
 


### PR DESCRIPTION
`python setup.py bdist_wheel` required `wheel` package.
So I ADDED IT!

related: @minhoryang